### PR TITLE
Use non-breakable spaces before \cite and \ref

### DIFF
--- a/chap1.tex
+++ b/chap1.tex
@@ -33,8 +33,8 @@ collections. To alleviate the problem, we need to automate the recognition
 process using computer-based image recognition techniques.
 
 The considerable progress we have seen in computer vision is largely due to
-local descriptor-based algorithms, such as SIFT\cite{lowe04}, and
-SURF\cite{surf08}, etc. The field of computer vision covers a wide range of
+local descriptor-based algorithms, such as SIFT~\cite{lowe04}, and
+SURF~\cite{surf08}, etc. The field of computer vision covers a wide range of
 topics. For the purpose of animal image biometric, this thesis will deal mostly
 with the image classification and recognition problems. Despite the stellar
 performance of these algorithms in the past decades, there exists a substantial
@@ -44,12 +44,12 @@ human and these machine-based algorithms, to \emph{Sloop}, the first pattern
 retrieval engine for animal biometric incorporating crowd-sourced relevance
 feedback.
 
-In the last few years, deep convolutional neural networks\cite{lecun95, kriz12}
+In the last few years, deep convolutional neural networks~\cite{lecun95, kriz12}
 have outperformed SIFTs and other descriptor-based techniques by a large margin
-in both object recognition and classification tasks\cite{kriz12, fisher14,
+in both object recognition and classification tasks~\cite{kriz12, fisher14,
 ILSVRC15}. In fact, the architecture has demonstrated recognition accuracy
 comparable to humans in several visual recognition tasks, such as recognizing
-faces\cite{deepface14}, and handwritten digits\cite{mnist13}. Motivated by the
+faces~\cite{deepface14}, and handwritten digits~\cite{mnist13}. Motivated by the
 preceding achievements, we integrate a pre-trained convolutional neural network
 into a new python version of Sloop, \emph{SlooPy}, as a separate image
 processing workflow.
@@ -82,11 +82,11 @@ constraints.
 
 \subsection{Image Recognition} % (fold) \label{sub:image_recognition} The
 emergence of convolutional neural network pushes forward the frontiers of all
-domains of computer vision \cite{lecun95}. Recent studies shows that
+domains of computer vision~\cite{lecun95}. Recent studies shows that
 convolutional neural network architecture clearly dominates the handcrafted
 features, and traditional orientation-based local descriptors, such as
-SIFT\cite{lowe04}, and SURF\cite{surf08}, etc. in classification
-tasks\cite{fisher14,kriz12,prelu15,ILSVRC15}.
+SIFT~\cite{lowe04}, and SURF~\cite{surf08}, etc. in classification
+tasks~\cite{fisher14,kriz12,prelu15,ILSVRC15}.
 
 The second part of the thesis presents a new architecture whose goal is to
 improve the identification accuracy as well as curtail or eliminate human

--- a/chap2.tex
+++ b/chap2.tex
@@ -52,19 +52,19 @@ animal in a given image A. Effectiveness of such identification system heavily
 depends on the choice of features on which the machine learning algorithms are
 applied.
 
-Current Sloop uses Scale Invariant Feature Transform (SIFT) \cite{lowe04} to
+Current Sloop uses Scale Invariant Feature Transform (SIFT)~\cite{lowe04} to
 perform such images ranking. Given an image and the four fiducial key points
 annotated by the biologists, Sloop transforms the images into SIFT object and
 compare it among the SIFTs of the existing images stored in the database, using
 Euclidean distance. After the ranking is generated, the biologists then look at
 the top matches and confirm whether the given pairs of images are matches or
-non-matches. 
+non-matches.
 
 While SIFT is still interesting for tasks that speed and simplicity are of
 major concerns, it requires tremendous amount of manual effort and training.
 Recent studies and competition results have proved that features learned via
 convolutional neural networks (CNN) outperform previous descriptors, including
-SIFT, on classification tasks by a wide margin\cite{fisher14}. Therefore,
+SIFT, on classification tasks by a wide margin~\cite{fisher14}. Therefore,
 replacing SIFT with convolutional neural networks seem to be a viable
 improvement to the system.
 
@@ -73,8 +73,8 @@ improvement to the system.
 Relevance Feedback is a technique that involves users in the retrieval process.
 Specifically, given a query that returns a set of initial results, the system
 takes user feedback on the initial results to improve the results returned from
-the later iterations when given the same or related query
-\cite{manning2008introduction}.
+the later iterations when given the same or related
+query~\cite{manning2008introduction}.
 
 \subsection{Crowdsourcing}
 
@@ -104,7 +104,7 @@ overtime.
 
 Convolutional Neural Network is a special kind of multi-layer neural networks,
 whose task is specialized to capture and encode visual patterns directly from
-raw pixel images \cite{lecun95}. 
+raw pixel images~\cite{lecun95}.
 
 \subsection{Face Verification and Siamese Network}
 
@@ -126,7 +126,7 @@ similar to identifying an identical twin by their blemishes except for, in this
 case, we have very high-order of multiple births.
 
 Most current face verification methods use hand-crafted features, which are
-often combined to improve the validation performance. In \cite{chopra05},
+often combined to improve the validation performance. In~\cite{chopra05},
 Chopra presented a new framework, \emph{Siamese Network}, as a solution to this
 problem. He proposed a training method that is used to learn a similarity
 metric from the data with the contrastive loss function, comprised of the sum

--- a/chap4.tex
+++ b/chap4.tex
@@ -13,10 +13,10 @@
 To study and understand the effect of relevance feedback to the retrieval
 results, we implement a simulator that reproduces the relevance feedback
 processes of sloop. The implementation of the simulator is described in
-\ref{sec:method} section. We then compare the initial ranked result set
+Section~\ref{sec:method}. We then compare the initial ranked result set
 outputted from SIFT computation with the results that undergo different rounds
-of relevance feedback with various configurations in the \ref{sec:experiments}
-section.
+of relevance feedback with various configurations in
+Section~\ref{sec:experiments}.
 
 \section{Methodology}
 \label{sec:method}
@@ -37,7 +37,7 @@ all the captures containing the same animals.
 
 Upon the retrieval of the new information from each batch, the simulator uses
 the identity graph to infer the answers of the unknown pairs. This imitates the
-in-database merging logic of the current version of Sloop\cite{sloopdocs}. The
+in-database merging logic of the current version of Sloop~\cite{sloopdocs}. The
 transitive relations are drawn from both matching pairs and non-matching pairs.
 For example, given capture $A$ is known to contain the same individual as that
 in capture $B$, and capture $B$ is known to contain the same individual as that
@@ -87,7 +87,7 @@ characteristic) curve, which is a plot of TPR and FPR, we use
 
 A precision recall curve is a plot of precision and recall as we  vary the
 threshold $\theta$. Precision or positive predictive value (PPV) is defined as
-following \cite{manning2008introduction}: $$PPV = \Pr{(y=1|\hat{y}=1)} =
+following~\cite{manning2008introduction}: $$PPV = \Pr{(y=1|\hat{y}=1)} =
 \frac{TP}{\hat{P}} = \frac{TP}{TP+FP}$$
 
 We evaluate the ranked retrieval performance of different relevance feedback
@@ -120,15 +120,15 @@ have to make in mind.
 
 We report three experiments corroborating the improvement of the retrieval
 results after various rounds of relevance feedback and different sampling
-strategies.  Experiment \ref{sub:batch_sizes} establishes that relevance
+strategies.  Experiment~\ref{sub:batch_sizes} establishes that relevance
 feedback improves the accretion of precision and recall of the preliminary
-results at various batch sizes.  Experiment \ref{sub:errors} shows the
+results at various batch sizes.  Experiment~\ref{sub:errors} shows the
 consequence of the erroneous answers at different error probabilities.
-Experiment \ref{sub:sampling_policies} compare the performance of various
+Experiment~\ref{sub:sampling_policies} compare the performance of various
 sampling policies.
 
 All experiments are performed on the Grand and Otago dataset described in
-Chapter \ref{cha:datasets}. Both datasets are annotated by the biologist, which
+Chapter~\ref{cha:datasets}. Both datasets are annotated by the biologist, which
 we take as our true labels. Table 
 
 \begin{table}[t]
@@ -223,7 +223,7 @@ We experiment with following policies:
 \section{Results and Discussion} % (fold)
 \label{sec:results}
 
-Figure \ref{pr_curves} displays the Precision-Recall graph at a given number of
+Figure~\ref{pr_curves} displays the Precision-Recall graph at a given number of
 sampled unknown pairs. With zero error probability, relevance feedback reduces
 the number of comparisons required for each specifies by a factor of 317 and
 307 for grand and otago respectively. Within four iterations of feedback loop,
@@ -248,7 +248,7 @@ interpolation of the new information.
 \label{sub:batch_sizes_res}
 
 Overall, from the graphs, MAP increases as we feed more data into the system.
-Figure \ref{fig:sizes_curves} indicates that we publish more unnecessary
+Figure~\ref{fig:sizes_curves} indicates that we publish more unnecessary
 tasks as we increase the batch size. The fewer captures there are in a batch,
 the lower the overall cost. Taking this idea one step further, we would like to
 infer the matches and merge the individuals as frequently as possible. However,

--- a/chap5.tex
+++ b/chap5.tex
@@ -12,10 +12,10 @@
 % Sloop-mturk: Crowdsourced relevance feedback on mturk
 \section{Sloop MTurk}
 
-As described in \ref{chap:relevance_feedback}, multiple rounds of relevance
+As described in Chapter~\ref{chap:relevance_feedback}, multiple rounds of relevance
 feedback accelerates precision and recall of the recognition. This chapter
 presents the architecture of \emph{Sloop MTurk}, the crowdsourced relevance
-feedback integration of Sloop. 
+feedback integration of Sloop.
 
 \begin{figure}[ht]
   \centering
@@ -25,7 +25,7 @@ feedback integration of Sloop.
 \end{figure}
 
 Sloop MTurk communicates with the crowdsourcing platform in order to provide
-human feedback on the original rankings. Our focus is on 
+human feedback on the original rankings. Our focus is on
 
 \subsection{Architecture}
 
@@ -42,7 +42,7 @@ workflow.
 
 In the first stage of the relevance feedback workflow, Sloop MTurk retrieves a
 number of unknown, and known image pairs from the database in the ratio
-described in \ref{subsub:validation}. The metadata about the retrieved pairs,
+described in Section~\ref{subsub:validation}. The metadata about the retrieved pairs,
 such as the answers to the known pairs, individual identification numbers, and
 source address, is stored in a lightweight SQLite database while the images are
 stored separately.
@@ -51,8 +51,8 @@ Sloop MTurk never publishes a duplicated \emph{unknown} pair onto MTurk. It
 actively checks with the local database before any retrieval if an unknown pair
 is ever published before. User can set the sampling policy of Sloop MTurk in
 the config file. The default value is set to use the normal sampling on the
-median whose performance has been shown in chapter
-\ref{chap:relevance_feedback}.
+median whose performance has been shown in
+Chapter~\ref{chap:relevance_feedback}.
 
 Sloop MTurk only downloads the images necessary for the tasks to minimize the
 bandwidth usage. Upon the retrieval, Sloop MTurk caches the image data into its
@@ -68,7 +68,7 @@ another machine, or to use other external web hosting.
 
 Sloop MTurk publishes the tasks onto MTurk immediately after all the
 information is fetched. The tasks published are available on Amazon Mechanical
-Turk under the title: 'Image Matching -- Animals' posted by user 'sloop'. 
+Turk under the title: 'Image Matching -- Animals' posted by user 'sloop'.
 % TODO Tell user that they need AWS access ID and secret key to programmatically
 % communicate with MTurk
 
@@ -91,12 +91,12 @@ Update command pushes the answers logged in the local database back to the
 original database so that the data is ready for another round of relevance
 feedback. The remote database server then infers the captures' cohort from the
 data pushed and the existing data, and then performs the merging logic
-accordingly\cite{sloopdocs}. 
+accordingly~\cite{sloopdocs}.
 
 The update command is separated from fetch for the debugging purpose. In
 practice, as we would like to update the upstream database as frequent as
-possible as we have seen in the Experiments section in
-\ref{chap:relevance_feedback}.
+possible as we have seen in the Experiments section,
+Chapter~\ref{chap:relevance_feedback}.
 
 \subsection{Platform Selection}
 
@@ -173,15 +173,15 @@ for each task.
 
 \subsection{Cost Model}
 
-Sloop MTurk uses the evaluation metrics mentioned in chapter
-\ref{chap:relevance_feedback} to measure the performance of the system.
+Sloop MTurk uses the evaluation metrics mentioned in
+Chapter~\ref{chap:relevance_feedback} to measure the performance of the system.
 
 \subsubsection{Correctness}
 
 To analyze the correctness, we are still using the Mean Average Precision to
 evaluate the correctness of the results. MAP has been shown to have especially
 good discrimination and stability on evaluating information retrieval
-systems\cite{manning2008introduction}.
+systems~\cite{manning2008introduction}.
 
 \subsubsection{Expense}
 

--- a/chap6.tex
+++ b/chap6.tex
@@ -107,7 +107,7 @@ captures in a cohort increases. However, the distribution of $\Pr{(score \mid
 
 \subsection{Earth Mover's Distance}
 
-We use Earth Mover's Distance (EMD)\cite{emd00} as our metric to calculate the
+We use Earth Mover's Distance (EMD)~\cite{emd00} as our metric to calculate the
 minimal cost required to transform $Pr(score|nonmatch)$ to $Pr(score|match)$.
 
 \begin{figure}[ht]
@@ -181,10 +181,10 @@ $$\Pr{(nonmatch \mid score)} = \frac{\Pr{(score \mid nonmatch)}\Pr{(nonmatch)}}
 \label{sec:sampling_policies}
 
 Starting with a completely unknown pairs, we would like to first get the idea
-of how the overall distribution looks like. As we have seen in chapter
-\ref{chap:relevance_feedback}, the unbiased sampling policies, such as Uniform,
-and AllScores, that broadly sample the data from the distribution seem to form
-a set of good candidates.
+of how the overall distribution looks like. As we have seen in
+Chapter~\ref{chap:relevance_feedback}, the unbiased sampling policies, such as
+Uniform, and AllScores, that broadly sample the data from the distribution seem
+to form a set of good candidates.
 
 Upon the retrieval of the general distribution, we would like to adaptively
 utilize the known data to determine the optimal sampling site. We experiment
@@ -212,6 +212,6 @@ Normal sampling policy.
 
 The adaptive sampling policy seem to perform averagely well. The performance
 does not differ from that of the other static sampling policies we have seen in
-chapter \ref{chap:relevance_feedback}.
+Chapter~\ref{chap:relevance_feedback}.
 
 % section proposed_sampling_policy (end)

--- a/chap7.tex
+++ b/chap7.tex
@@ -9,10 +9,10 @@
 % * Data gathering procedure (experiments)
 \chapter{Convolutional Neural Network}
 
-We first describe the our new architecture in the System Overview (section
-\ref{system}). Then in the Experiments (section \ref{experiments}), we compare
-the performance of the current identification method within the existing
-pattern retrieval engine with that of the new architecture.
+We first describe the our new architecture in the System Overview
+(Section~\ref{system}). Then in the Experiments (Section~\ref{experiments}), we
+compare the performance of the current identification method within the
+existing pattern retrieval engine with that of the new architecture.
 
 \section{System Overview} \label{system}
 
@@ -20,8 +20,8 @@ In this section, we begin by presenting the architecture that outputs a
 yes-or-no answer to the question whether, given two images A and B, the animal
 in image A the same individual as the animal in image B.
 
-The proposed architecture comprises two major modules shown in Figure
-\ref{fig:cnn_overview}.
+The proposed architecture comprises two major modules shown in
+Figure~\ref{fig:cnn_overview}.
 
 \begin{figure}[ht]
   \centering
@@ -46,15 +46,15 @@ discover and optimize features for the specific task at hand.
 
 Instead of hand-picking the features to learn the similarity matrices from the
 data, a convolutional neural network (CNN) will be used as a feature extractor
-similar to the solution proposed in \cite{chopra05} for face verification.
+similar to the solution proposed in~\cite{chopra05} for face verification.
 
-We use a pre-trained CNN, AlexNet by Krizhevsky et al. \cite{kriz12} trained on
-ImageNet \cite{imagenet}, which contains 1.2 million images with 1000
+We use a pre-trained CNN, AlexNet by Krizhevsky et al.~\cite{kriz12} trained on
+ImageNet~\cite{imagenet}, which contains 1.2 million images with 1000
 categories. To convert the CNN into a feature extractor, we strip out the last
 fully-connected layer, which, in this case, outputs 1000 class scores for
 ImageNet classification task. According to AlexNet architecture, this would
 output a sparse 4096 dimensional vector for every images. The technique is
-called transfer learning \cite{transfer}.
+called transfer learning~\cite{transfer}.
 
 We map all the available images as well as the input image to points in a low
 dimensional space (4096-D compare to $227 \times 227$-D) using the
@@ -86,7 +86,7 @@ accurately recognize the animal regardless of its position in the image.
 
 The translation invariant property emerges as a result of the contiguity in our
 pooling regions and the fact that we only pool features generated from the same
-hidden units \cite{ufldl}. Even though the property is desirable to reduce the
+hidden units~\cite{ufldl}. Even though the property is desirable to reduce the
 translation noise, this disallows learning some features that are described by
 their relative positions. For example, individual A with a star-shaped spot
 right above its eye may be confused with another individual B who also has
@@ -95,11 +95,11 @@ star-shaped spot underneath its eye.
 The solution to such problem is to experiment with different pattern of pooling
 regions, and relax the parameter sharing scheme. Since we are using an existing
 pre-trained architecture, it is hard to tailor to fit our data. The improvement
-can be included in the future work \ref{cha:future_work}.
+can be included in the future work~\ref{cha:future_work}.
 
 \textbf{Caffe}
 
-The CNN is implemented in python using Caffe\cite{caffe}, a deep learning
+The CNN is implemented in python using Caffe~\cite{caffe}, a deep learning
 framework developed by the Berkeley Vision and Learning Center (BVLC).
 
 \subsection{Match Recognition}
@@ -164,9 +164,9 @@ We have implemented following algorithms as our match recognizer:
   \item Passive-Aggressive with squared hinge loss (PA-II)
 \end{itemize}
 
-We compare the performance of each classifier in the Experiments section
-(\ref{experiments}). The classifier with the best performance will be selected
-for our final design.
+We compare the performance of each classifier in the Experiments
+section~(\ref{experiments}). The classifier with the best performance will be
+selected for our final design.
 
 \section{Experiments} \label{experiments}
 
@@ -178,7 +178,7 @@ comparison between the presented solutions.
 
 The training and testing data is available in the existing Sloop system. We
 base our experiments on both species of skinks: \emph{Grand} and \emph{Otago}
-mentioned in \ref{cha:datasets}.
+mentioned in Chapter~\ref{cha:datasets}.
 
 For our experiments, each image from both databases is reduced to the size of
 $227 \times 227$ pixels so that it can be directly fed into the CNN

--- a/chap8.tex
+++ b/chap8.tex
@@ -16,10 +16,10 @@ biologists.
 
 \textbf{Input Processing}
 
-According to the proposed architecture in section \ref{system}, we have
+According to the proposed architecture in Section~\ref{system}, we have
 experimented with both method of input processing, namely, concatenation and
-computing the difference. The results are shown in table
-\ref{concatenation-table} and \ref{tab:results_table}.
+computing the difference. The results are shown in
+Table~\ref{concatenation-table} and Table~\ref{tab:results_table}.
 
 
 \begin{table}[t]
@@ -132,7 +132,7 @@ difference as the input.
     \clearpage% Flush page
 }
 
-Considering the classification results in \ref{tab:results_table}, all the
+Considering the classification results in Table~\ref{tab:results_table}, all the
 classifiers seem to perform equally well on the test data considering the
 F-beta score. SVM with radial bas kernel function yields the most stable
 performance with very high precision for both species. The offline algorithms


### PR DESCRIPTION
The ~ character makes sure the number can't be separated from the word
before it.

While here, Add a few missing reference labels; use 'in Chapter 2'
rather than 'in 2'.  Also make sure the word preceeding the reference is
capitalized (Figure, Chapter, Section, etc.).
