### PR TITLE
Silence chktex "space before label" warnings

### DIFF
--- a/chap2.tex
+++ b/chap2.tex
@@ -33,7 +33,7 @@ The system is divided into two major components:
   \centering
   \includegraphics[width=\textwidth]{sloop/system}
   \caption{Score Distribution}
-  \label{fig:sloop_overview}
+  \label{fig:sloop_overview} %chktex 24
 \end{figure}
 
 \begin{enumerate}

--- a/chap3.tex
+++ b/chap3.tex
@@ -38,7 +38,7 @@ $\times$ 1215 pixels
 \begin{table}[t]
 \captionsetup{justification=centering}
   \caption{Summary of each database}
-  \label{database-table}
+  \label{database-table} %chktex 24
   \centering
   \begin{tabular}{llllllll}
     \toprule
@@ -111,12 +111,12 @@ where $C$ is a capture and $I$ is an image in a capture.
   \centering
   \includegraphics[width=\textwidth]{dataset/grand/scores}
   \caption{Score Distribution}
-  \label{fig:grand_scores}
+  \label{fig:grand_scores} %chktex 24
 \end{figure}
 
 \begin{figure}[ht]
   \centering
   \includegraphics[width=\textwidth]{dataset/otago/scores}
   \caption{Score Distribution}
-  \label{fig:otago_scores}
+  \label{fig:otago_scores} %chktex 24
 \end{figure}

--- a/chap4.tex
+++ b/chap4.tex
@@ -134,7 +134,7 @@ we take as our true labels. Table
 \begin{table}[t]
 \captionsetup{justification=centering}
   \caption{Number of capture pairs for each species}
-  \label{species-num-pairs}
+  \label{species-num-pairs} %chktex 24
   \centering
   \begin{tabular}{lc}
     \toprule
@@ -235,7 +235,6 @@ inclination of precision and recall is expected largely due to the
 interpolation of the new information.
 
 \begin{figure}[h!]
-
   \centering
   \subfloat[Grand]{\includegraphics[width=0.8\textwidth]{pr/grand}}\\
   \subfloat[Otago]{\includegraphics[width=0.8\textwidth]{pr/otago}}
@@ -269,10 +268,10 @@ size that is still large enough to engage the workers.
   \subfloat[Grand]{\includegraphics[width=0.8\textwidth]{sizes/grtotal}}\\
   \subfloat[Otago]{\includegraphics[width=0.8\textwidth]{sizes/ottotal}}
   \captionsetup{justification=centering}
-  \label{fig:sizes_curves}
   \caption{The total number of unknown pairs marked to achieve $MAP=1$
   ($Error=0$, \texttt{batch\_size}$=100$). Notice that this equals the total 
   number of tasks published to achieve $MAP=1$. }
+  \label{fig:sizes_curves} %chktex 24
 \end{figure}
 
 % subsection batch_size (end)
@@ -294,7 +293,7 @@ eventually.
   \centering
   \subfloat[Grand]{\includegraphics[width=\textwidth]{errors/graoc}}
   \caption{Mean Average Precision for different probabilities of error}
-  \label{fig:grand_aoc}
+  \label{fig:grand_aoc} %chktex 24
 \end{figure}
 % subsection errors (end)
 

--- a/chap5.tex
+++ b/chap5.tex
@@ -21,7 +21,7 @@ feedback integration of Sloop.
   \centering
   \includegraphics[width=0.8\textwidth]{sloop/turk_system}
   \caption{Sloop Architecture with Sloop MTurk integration}
-  \label{fig:turk_overview}
+  \label{fig:turk_overview} %chktex 24
 \end{figure}
 
 Sloop MTurk communicates with the crowdsourcing platform in order to provide

--- a/chap6.tex
+++ b/chap6.tex
@@ -35,15 +35,15 @@ $$\Pr{(score=s \mid nonmatch)} = \frac{\texttt{\# nonmatches\_whose\_score=s}}
   \centering
   \subfloat[][Probability of Score given matches/non-matches]
   {\includegraphics[width=0.95\textwidth]{dataset/grand/psm}}
-  \label{fig:grand_psm}\\
+  \label{fig:grand_psm}\\ %chktex 24
   \subfloat[][CDF of Score given matches/non-matches]
   {\includegraphics[width=0.95\textwidth]{dataset/grand/csm}}
-  \label{fig:grand_csm}\\
+  \label{fig:grand_csm}\\ %chktex 24
   \subfloat[][Difference between the CDF of Score given matches/non-matches]
   %$F\[non-match\]$ and $F\[match\]$
   {\includegraphics[width=0.95\textwidth]{dataset/grand/dsm}}
-  \label{fig:grand_dsm}
   \caption{Functions of Score given matches/non-matches}
+  \label{fig:grand_dsm} %chktex 24
 \end{figure}
 
 From the plot above, we can deduct following conclusions:
@@ -63,15 +63,15 @@ $$\Pr{(score \mid match)} > \Pr{(score \mid nonmatch)} \mbox{ where } score\in [
   \centering
   \subfloat[][Probability of Score given matches/non-matches]
   {\includegraphics[width=0.95\textwidth]{dataset/otago/psm}}
-  \label{fig:otago_psm}\\
+  \label{fig:otago_psm}\\ %chktex 24
   \subfloat[][CDF of Score given matches/non-matches]
   {\includegraphics[width=0.95\textwidth]{dataset/otago/csm}}
-  \label{fig:otago_csm}\\
+  \label{fig:otago_csm}\\ %chktex 24
   \subfloat[][Difference between the CDF of Score given matches/non-matches]
     %$F\[non-match\]$ and $F\[match\]$
   {\includegraphics[width=0.95\textwidth]{dataset/otago/dsm}}
-  \label{fig:otago_dsm}
   \caption{Functions of Score given matches/non-matches}
+  \label{fig:otago_dsm} %chktex 24
 \end{figure}
 
 
@@ -81,11 +81,11 @@ $$\Pr{(score \mid match)} > \Pr{(score \mid nonmatch)} \mbox{ where } score\in [
   \centering
   \subfloat[][Probability of a matching score at a given cohort size]
   {\includegraphics[width=0.95\textwidth]{dataset/grand/pscohort}}
-  \label{fig:grand_pscohort}\\
+  \label{fig:grand_pscohort}\\ %chktex 24
   \subfloat[][Probability of a score \emph{not} in a given cohort size]
   {\includegraphics[width=0.95\textwidth]{dataset/grand/psnoncohort}}
-  \label{fig:grand_psnoncohort}
   \caption{Probability of a score given a range of cohort size}
+  \label{fig:grand_psnoncohort} %chktex 24
 \end{figure}
 
 Initially, we expected that as the cohort size increases, $\Pr{(score \mid
@@ -98,11 +98,11 @@ captures in a cohort increases. However, the distribution of $\Pr{(score \mid
   \centering
   \subfloat[][Probability of a matching score at a given cohort size]
   {\includegraphics[width=0.95\textwidth]{dataset/otago/pscohort}}
-  \label{fig:otago_pscohort}\\
+  \label{fig:otago_pscohort}\\ %chktex 24
   \subfloat[][Probability of a score \emph{not} in a given cohort size]
   {\includegraphics[width=0.95\textwidth]{dataset/otago/psnoncohort}}
-  \label{fig:otago_psnoncohort}
   \caption{Probability of a score given a range of cohort size}
+  \label{fig:otago_psnoncohort} %chktex 24
 \end{figure}
 
 \subsection{Earth Mover's Distance}
@@ -114,7 +114,7 @@ minimal cost required to transform $Pr(score|nonmatch)$ to $Pr(score|match)$.
   \centering
   \includegraphics[width=0.95\textwidth]{dataset/grand/emd}
   \caption{Earth Mover's Distance between the probability distributions}
-  \label{fig:grand_emd}
+  \label{fig:grand_emd} %chktex 24
 \end{figure}
 
 Initially, we also expected that the relationship between EMD and cohort size
@@ -125,7 +125,7 @@ $Pr(score|nonmatch)$ and $Pr(score|match)$.
   \centering
   \includegraphics[width=0.95\textwidth]{dataset/otago/emd}
   \caption{Earth Mover's Distance between the probability distributions}
-  \label{fig:otago_emd}
+  \label{fig:otago_emd} %chktex 24
 \end{figure}
 
 \subsection{Entropy of $\Pr{[score|match]}$ at different cohort sizes}
@@ -137,22 +137,23 @@ $H(X|Y)$ = amount of randomness in the random variable X given the event Y.
   \centering
   \subfloat[][Entropy of $\Pr{[score|match]}$ at different cohort sizes]
   {\includegraphics[width=0.95\textwidth]{dataset/grand/ent_psm}}
-  \label{fig:grand_ent_psm}\\
+  \label{fig:grand_ent_psm}\\ %chktex 24
   \subfloat[][Entropy of $\Pr{[score|nonmatch]}$ at different cohort sizes]
   {\includegraphics[width=0.95\textwidth]{dataset/grand/ent_psnm}}
-  \label{fig:grand_ent_psnm}\\
   \caption{Relationship between $\Pr{[score|match]}$ and $\Pr{[score|nonmatch]}$}
+  \label{fig:grand_ent_psnm}\\ %chktex 24
 \end{figure}
 
 \begin{figure}[ht]
   \centering
   \subfloat[][Entropy of $\Pr{[score|match]}$ at different cohort sizes]
   {\includegraphics[width=0.95\textwidth]{dataset/otago/ent_psm}}
-  \label{fig:otago_ent_psm}\\
+  \label{fig:otago_ent_psm}\\ %chktex 24
   \subfloat[][Entropy of $\Pr{[score|nonmatch]}$ at different cohort sizes]
   {\includegraphics[width=0.95\textwidth]{dataset/otago/ent_psnm}}
-  \label{fig:otago_ent_psnm}\\
+  \label{fig:otago_ent_psnm}\\ %chktex 24
   \caption{Relationship between $\Pr{[score|match]}$ and $\Pr{[score|nonmatch]}$}
+  \label{fig:emd_grand} %chktex 24
 \end{figure}
 
 \subsection{Probability of a Matches/Non-matches}
@@ -167,14 +168,14 @@ $$\Pr{(nonmatch \mid score)} = \frac{\Pr{(score \mid nonmatch)}\Pr{(nonmatch)}}
   \centering
   \includegraphics[width=0.95\textwidth]{dataset/grand/pms}
   \caption{Probability of matches/non-matches given score}
-  \label{fig:grand_pms}
+  \label{fig:grand_pms} %chktex 24
 \end{figure}
 
 \begin{figure}[ht]
   \centering
   \includegraphics[width=0.95\textwidth]{dataset/otago/pms}
   \caption{Probability of matches/non-matches given score}
-  \label{fig:otago_pms}
+  \label{fig:otago_pms} %chktex 24
 \end{figure}
 
 \section{Adaptive Sampling Policies} % (fold)
@@ -207,7 +208,7 @@ Normal sampling policy.
   \centering
   \includegraphics[width=0.8\textwidth]{otago}
   \caption{Mean Average Precision for the new sampling policies}
-  \label{fig:otago_adaptive_aoc}
+  \label{fig:otago_adaptive_aoc} %chktex 24
 \end{figure}
 
 The adaptive sampling policy seem to perform averagely well. The performance

--- a/chap7.tex
+++ b/chap7.tex
@@ -14,7 +14,7 @@ We first describe the our new architecture in the System Overview (section
 the performance of the current identification method within the existing
 pattern retrieval engine with that of the new architecture.
 
-\section{System Overview} \label{system}
+\section{System Overview}\label{system}
 
 In this section, we begin by presenting the architecture that outputs a
 yes-or-no answer to the question whether, given two images A and B, the animal
@@ -27,7 +27,7 @@ The proposed architecture comprises two major modules shown in Figure
   \centering
   \includegraphics[width=\textwidth]{system/overview}
   \caption{System Overview}
-  \label{fig:cnn_overview}
+  \label{fig:cnn_overview} %chktex 24
 \end{figure}
 
 \begin{enumerate}
@@ -168,7 +168,7 @@ We compare the performance of each classifier in the Experiments section
 (\ref{experiments}). The classifier with the best performance will be selected
 for our final design.
 
-\section{Experiments} \label{experiments}
+\section{Experiments}\label{experiments}
 
 In this section, we first introduce the datasets used in the experiments, then
 present the detailed evaluation of the variants of our architecture and the

--- a/chap8.tex
+++ b/chap8.tex
@@ -26,7 +26,7 @@ computing the difference. The results are shown in table
 \captionsetup{justification=centering}
   \caption{Precision (P), recall (R), and F-score (F) of the classification
   results for the input processing with feature vectors concatenation}
-  \label{concatenation-table}
+  \label{concatenation-table} %chktex 24
 \centering
 \begin{tabular}{lllllllllllllllllll}
     \toprule


### PR DESCRIPTION
This is mostly to silence LaTeX's checker. Spaces before labels can in
some cases bause problems, but everything is fine here. This just tells
chktex to stop complaining about it.

While here, move a few labels to after the captions; this is necessary
because the caption creates the number that the label references, so
label must come after it.
