### PR TITLE
Clean up spacing and fix misc LaTeX errors

### DIFF
--- a/abstract.tex
+++ b/abstract.tex
@@ -30,7 +30,7 @@ improvements to the recognition process and ranked retrival of Sloop, the first
 image retrieval engine that couples automated pattern recognition with
 crowd-sourced relevance feedback for individual animal identification.
 
-With a crowd-sourc`ed relevance feedback simulator, we report a number of
+With a crowd-sourced relevance feedback simulator, we report a number of
 studies corroborating the acceration of precision and recall of the retreival
 results after various rounds of relevance feedback and the effects of the error
 propagation.

--- a/chap1.tex
+++ b/chap1.tex
@@ -85,7 +85,7 @@ emergence of convolutional neural network pushes forward the frontiers of all
 domains of computer vision~\cite{lecun95}. Recent studies shows that
 convolutional neural network architecture clearly dominates the handcrafted
 features, and traditional orientation-based local descriptors, such as
-SIFT~\cite{lowe04}, and SURF~\cite{surf08}, etc. in classification
+SIFT~\cite{lowe04}, and SURF~\cite{surf08}, etc.\ in classification
 tasks~\cite{fisher14,kriz12,prelu15,ILSVRC15}.
 
 The second part of the thesis presents a new architecture whose goal is to
@@ -105,7 +105,7 @@ varies from species to species. The extracted feature object of an image is then
 passed into the pattern recognition algorithm to find the matches existed in the
 system. Current Sloop locates the animal and necessary features of an image by
 having the user click on the key points of the animal, and then calculates the
-feature vector using SIFT. It performs the matching by scoring the similarity of
+feature vector using SIFT\@. It performs the matching by scoring the similarity of
 the SIFT object. 
 
 Traditional approaches in machine learning generally require training samples to

--- a/chap2.tex
+++ b/chap2.tex
@@ -113,7 +113,7 @@ image, can be reduced to following \emph{decision problem}:
 \begin{quote}
 \centering
 Given two images A and B, is the animal in image A the same individual as the
-animal in image B?
+animal in image B\@?
 \end{quote}
 
 Our problem is somewhat similar to the face verification problem, which

--- a/chap4.tex
+++ b/chap4.tex
@@ -47,7 +47,7 @@ $A$ and $C$. Once such transitive inference is made, it adds $C$ to the
 identity graph. Then, it continues to sample a new batch iteratively until the
 distribution satisfies the convergence condition specified by the user.
 
-The correctness of such inference relies on the validity of the premises, i.e.
+The correctness of such inference relies on the validity of the premises, i.e.\
 if the answers to the matches are correct then the conclusion must also hold.
 Problems arise when our seemingly \emph{correct} answers are, in fact,
 incorrect. With the auto merging, the error propagates rapidly. An incorrect
@@ -240,7 +240,7 @@ interpolation of the new information.
   \subfloat[Otago]{\includegraphics[width=0.8\textwidth]{pr/otago}}
   \captionsetup{justification=centering}
   \caption{Precision-Recall graph ($Error=0$, \texttt{batch\_size}$=400$)}
-  \label{pr_curves}
+  \label{pr_curves} %chktex 24
 \end{figure}
 
 \subsection{Batch Sizes} % (fold)

--- a/chap5.tex
+++ b/chap5.tex
@@ -56,7 +56,7 @@ Chapter~\ref{chap:relevance_feedback}.
 
 Sloop MTurk only downloads the images necessary for the tasks to minimize the
 bandwidth usage. Upon the retrieval, Sloop MTurk caches the image data into its
-local storage on the file system running on NGINX. Caching image data on the
+local storage on the file system running on NGINX\@. Caching image data on the
 filesystem eliminates the network latency and cuts down the data transfer
 overhead because fetching large responses, like the images, over the network is
 both slow and expensive. The advantage of storing images on the file system,
@@ -68,7 +68,7 @@ another machine, or to use other external web hosting.
 
 Sloop MTurk publishes the tasks onto MTurk immediately after all the
 information is fetched. The tasks published are available on Amazon Mechanical
-Turk under the title: 'Image Matching -- Animals' posted by user 'sloop'.
+Turk under the title: `Image Matching --- Animals' posted by user `sloop'.
 % TODO Tell user that they need AWS access ID and secret key to programmatically
 % communicate with MTurk
 
@@ -107,7 +107,7 @@ popular crowdsourcing platforms.
 \subsection{Human Intelligence Task (HIT)}
 
 Tasks published on MTurk are called Human
-Intelligence Tasks (HITs). The term 'HIT' and 'tasks' are going to be used
+Intelligence Tasks (HITs). The terms `HIT' and `tasks' are going to be used
 interchangeably throughout this report.
 
 Requesters publish the tasks that they need to accomplish onto Amazon

--- a/chap7.tex
+++ b/chap7.tex
@@ -67,7 +67,7 @@ aforementioned CNN architecture.
   \subfloat[][The first layer output, \texttt{conv1}]
     {\includegraphics[width=8cm]{preprocess/blob20conv1}}
   \subfloat[][The fifth layer after pooling, \texttt{pool5}]
-    {\includegraphics[width=8cm]{preprocess/blob20pool5}}] \\
+    {\includegraphics[width=8cm]{preprocess/blob20pool5}} \\
   \subfloat[][The first layer output, \texttt{conv1}]
     {\includegraphics[width=8cm]{preprocess/lastconv1}}
   \subfloat[][The fifth layer after pooling, \texttt{pool5}]
@@ -211,10 +211,10 @@ our datasets using two different techniques.
 \end{itemize}
 
 For each dataset, we partition the set of the \emph{generated pairs} into three
-sets: train set (60\%), validation set (20\%), and test set (20\%)respectively.
-We prevent overfitting problem by monitoring the model’s performance on a
+sets: train set (60\%), validation set (20\%), and test set (20\%) respectively.
+We prevent overfitting problem by monitoring the model's performance on a
 validation set, acting as a representative of future test examples. If the
-model’s performance ceases to improve sufficiently on the validation set then
+model's performance ceases to improve sufficiently on the validation set then
 we test the model on teh actual test set.
 
 

--- a/chap8.tex
+++ b/chap8.tex
@@ -64,7 +64,7 @@ difference as the input.
         \caption{Precision (P), recall (R), and F-score (F) of the linear
         classifier with absolute feature difference on train, validation, and
         test set of the four datasets}
-        \label{tab:results_table}
+        \label{tab:results_table} %chktex 24
 
       \centering % Center table
       \hskip-2.0cm\begin{tabular}{lllll|lll|lll|lll|lllll}

--- a/cover.tex
+++ b/cover.tex
@@ -66,7 +66,7 @@
 %% \end{abstractpage} commands.
 
 % First copy: start a new page, and save the page number.
-\cleardoublepage
+\cleardoublepage%
 % Uncomment the next line if you do NOT want a page number on your
 % abstract and acknowledgments pages.
 % \pagestyle{empty}
@@ -84,14 +84,14 @@
 % \input{abstract}
 % \end{abstractpage}
 
-\cleardoublepage
+\cleardoublepage%
 
 \section*{Acknowledgments}
 
 This thesis would not have been possible without the support and help from many
 individuals to whom I am sincerely appreciated.
 
-First, I would like to express my deepest gratitude to my advisor, Dr. Srinivas
+First, I would like to express my deepest gratitude to my advisor, Dr.\ Srinivas
 Ravela, for his expert guidance, profound understanding, and encouragement
 throughout my study and research. Without his counsel and great patience, this
 work would truly not have been possible.


### PR DESCRIPTION
- Use proper inter-word and inter-sentence spacing (\@ and )
- Use proper quitation marks (`)
- Remove some unicode characters
- Use correct em-dash
- Remove a few stray characters
- Resolve "command terminated with space errors"
- Silence a few more chktex warnings
