### PR TITLE
Beautify tables

### DIFF
--- a/chap3.tex
+++ b/chap3.tex
@@ -40,7 +40,7 @@ $\times$ 1215 pixels
   \caption{Summary of each database}
   \label{database-table} %chktex 24
   \centering
-  \begin{tabular}{llllllll}
+  \begin{tabular}{lccccccc}
     \toprule
     & \multicolumn{3}{c}{Number of Images} & & &
         \multicolumn{2}{c}{Images per Individual} \\

--- a/chap7.tex
+++ b/chap7.tex
@@ -222,32 +222,24 @@ we test the model on teh actual test set.
 \captionsetup{justification=centering}
   \caption{Details of the train, validation, and test set for the four datasets}
 \centering
-  \begin{tabular}{lllll}
+  \begin{tabular}{llrcc}
     \toprule
-    \multicolumn{2}{c}{Name (NTotal)}      & NPairs & \% Match & \% Non-match \\
+    \multicolumn{2}{l}{Name (NTotal)}      & NPairs & \% Match & \% Non-match \\
     \midrule
     \multirow{3}{*}{Gr$^{L}$-I (10878)}  & Train & 6526 & 0.07 & 0.93 \\
-\cmidrule{2-5}
                                  & Val   & 2175 & 0.07 & 0.93 \\
-\cmidrule{2-5}
                           & Test  & 2177 & 0.07 & 0.93 \\
-\hline
+\midrule
 \multirow{3}{*}{Ot$^{L}$-I (10878)}  & Train & 6526 & 0.06 & 0.94 \\
-\cmidrule{2-5}
                                  & Val   & 2175 & 0.06 & 0.94 \\
-\cmidrule{2-5}
                                  & Test  & 2177 & 0.06 & 0.94 \\
-\hline
+\midrule
   \multirow{3}{*}{Gr$^{L}$-II} & Train & 2926 & 0.13 & 0.87\\
-\cmidrule{2-5}
                                  & Val   & 351 & 0.38 & 0.62\\
-\cmidrule{2-5}
                                  & Test  & 1035 & 0.25 & 0.75\\
-    \hline
+    \midrule
     \multirow{3}{*}{Ot$^{L}$-II} & Train & 3240 & 0.10 & 0.90\\
-\cmidrule{2-5}
                                  & Val   & 561 & 0.31 & 0.69\\
-\cmidrule{2-5}
                                  & Test  & 561& 0.26 & 0.73\\
     \bottomrule
   \end{tabular}

--- a/chap8.tex
+++ b/chap8.tex
@@ -28,19 +28,21 @@ Table~\ref{concatenation-table} and Table~\ref{tab:results_table}.
   results for the input processing with feature vectors concatenation}
   \label{concatenation-table} %chktex 24
 \centering
-\begin{tabular}{lllllllllllllllllll}
+% The 'C' column type is defined in the document preamble. It adds
+% extra space to the left of the column to replace vertical rules. The
+% 'H' column type is for headers above it, which need to account for
+% the extra space.
+\begin{tabular}{llCccCccCcc}
     \toprule
-    \multicolumn{2}{c}{\multirow{2}{*}{Dataset} } & \multicolumn{3}{c}{PCT} &
-        \multicolumn{3}{c}{PA-I} & \multicolumn{3}{c}{PA-II}\\
-  \cmidrule{3-10}
+    \multicolumn{2}{c}{\multirow{2}{*}{Dataset} } & \multicolumn{3}{H}{PCT} &
+        \multicolumn{3}{H}{PA-I} & \multicolumn{3}{c}{PA-II}\\
+  \cmidrule{3-11}
         & & P & R & F  & P & R & F  & P & R & F \\
     \midrule
     \multirow{3}{*}{Gr$^{L}$-I}  & Train & 0.01 & 0.03 & 0.01 & 0.04 & 0.01 
         & 0.01 & 0.00 & 0.00 & 0.00 \\
-    \cmidrule{2-11}
                                  & Val   & 0.40 & 0.13 & 0.08 & 0.23 & 0.06
         & 0.08 & 0.46 & 0.08 & 0.06 \\
-    \cmidrule{2-11}
                                  & Test  & 0.01 & 0.05 & 0.02 & 0.03 & 0.01
         & 0.01 &  0.00 & 0.02 & 0.01 \\
     \bottomrule
@@ -67,12 +69,16 @@ difference as the input.
         \label{tab:results_table} %chktex 24
 
       \centering % Center table
-      \hskip-2.0cm\begin{tabular}{lllll|lll|lll|lll|lllll}
+        % The 'C' column type is defined in the document preamble. It adds
+        % extra space to the left of the column to replace vertical rules. The
+        % 'H' column type is for headers above it, which need to account for
+        % the extra space.
+      \hskip-2.0cm\begin{tabular}{llCccCccCccCccCcc}
           \toprule
 
-          \multicolumn{2}{c}{\multirow{2}{*}{Dataset} } & \multicolumn{3}{c}{SVM}
-            & \multicolumn{3}{c}{SVM-RBF} & \multicolumn{3}{c}{PCT}
-            & \multicolumn{3}{c}{PA-I} & \multicolumn{3}{c}{PA-II}\\
+          \multicolumn{2}{c}{\multirow{2}{*}{Dataset} } & \multicolumn{3}{H}{SVM}
+            & \multicolumn{3}{H}{SVM-RBF} & \multicolumn{3}{H}{PCT}
+            & \multicolumn{3}{H}{PA-I} & \multicolumn{3}{c}{PA-II}\\
         \cmidrule{3-17}
                                                     & & P & R & F  & P & R & F 
                                                     & P & R & F  & P & R & F & P
@@ -81,50 +87,42 @@ difference as the input.
           \multirow{3}{*}{Gr$^{L}$-I}  & Train & 0.91 & 0.21 & 0.34 & 0.97 & 0.18
             & 0.30 & 0.40 & 0.26 & 0.32 & 0.57 & 0.31 & 0.29 & 0.57 & 0.29 & 0.30
             \\
-          %\cmidrule{2-17}
                                        & Val   & 0.95 & 0.23 & 0.37 & 0.99 & 0.19
                                        & 0.32 & 0.58 & 0.37 & 0.45 & 0.65 & 0.48
                                        & 0.38  & 0.67 & 0.44 & 0.39      \\
-          %\cmidrule{2-17}
-                                       & Test  & 0.82 & 0.20 & 0.33 & 1.0 & 0.21
+                                       & Test  & 0.82 & 0.20 & 0.33 & 1.00 & 0.21
                                        & 0.35 &  0.42 & 0.24 & 0.30 & 0.54
                                        & 0.33 & 0.28 & 0.52 & 0.29 & 0.28     \\
-          \hline
+          \midrule
           \multirow{3}{*}{Ot$^{L}$-I}  & Train & 0.64 & 0.24 & 0.32 & 0.88 & 0.21
           & 0.34  & 0.45 & 0.32 & 0.29 & 0.37 & 0.16 & 0.23 & 0.36 & 0.27
           & 0.30     \\
-      %\cmidrule{2-17}
                                        & Val   & 0.81 & 0.42 & 0.51 & 0.90 & 0.24
                                        & 0.37 & 0.55 & 0.54 & 0.42 & 0.89 & 0.30
                                        & 0.39 & 0.65 & 0.55 & 0.59     \\
-      %\cmidrule{2-17}
                                        & Test  & 0.66 & 0.26 & 0.33 & 0.90 & 0.20
                                        & 0.32 & 0.46 & 0.39 & 0.33 & 0.36 & 0.17
                                        & 0.23 & 0.42 & 0.32 & 0.36     \\
-          \hline
+          \midrule
           \multirow{3}{*}{Gr$^{L}$-II} & Train & 0.92 & 0.35 & 0.50 & 0.99 & 0.21
           & 0.34 & 0.99 & 0.27 & 0.43 & 0.89 & 0.48 & 0.63 & 0.83 & 0.57 & 0.67 
           \\
-      %\cmidrule{2-17}
-                                       & Val   & 0.79 & 0.20 & 0.32 & 1.0 & 0.20
+                                       & Val   & 0.79 & 0.20 & 0.32 & 1.00 & 0.20
                                        & 0.33 & 0.93 & 0.19 & 0.32 & 0.76 & 0.21
                                        & 0.33 & 0.66 & 0.24 & 0.36     \\
-      %\cmidrule{2-17}
-                                       & Test  & 0.85 & 0.22 & 0.35 & 1.0 & 0.18
+                                       & Test  & 0.85 & 0.22 & 0.35 & 1.00 & 0.18
                                        & 0.30 & 0.92 & 0.19 & 0.31 & 0.86 & 0.20
                                        & 0.32 & 0.69 & 0.22 & 0.34     \\
-          \hline
-          \multirow{3}{*}{Ot$^{L}$-II} & Train & 0.57 & 0.29 & 0.38 & 1.0 & 0.22
-          & 0.38 & 0.53 & 0.70 & 0.60 & 0.59 & 0.78 & 0.67 & 1.0 & 0.25
+          \midrule
+          \multirow{3}{*}{Ot$^{L}$-II} & Train & 0.57 & 0.29 & 0.38 & 1.00 & 0.22
+          & 0.38 & 0.53 & 0.70 & 0.60 & 0.59 & 0.78 & 0.67 & 1.00 & 0.25
           & 0.40     \\
-      %\cmidrule{2-17}
-                                       & Val  & 0.57 & 0.68 & 0.62 & 1.0 & 0.24
+                                       & Val  & 0.57 & 0.68 & 0.62 & 1.00 & 0.24
                                        & 0.39 & 0.53 & 0.37 & 0.43 & 0.56 & 0.30
                                        & 0.39 & 0.97 & 0.19 & 0.32   \\
-      %\cmidrule{2-17}
-                                       & Test  & 0.57 & 0.28 & 0.38  & 1.0
+                                       & Test  & 0.57 & 0.28 & 0.38  & 1.00
                                        & 0.19 & 0.32 & 0.43 & 0.36 & 0.39 & 0.50
-                                       & 0.32 & 0.39 & 1.0 & 0.22 & 0.37     \\
+                                       & 0.32 & 0.39 & 1.00 & 0.22 & 0.37     \\
           \bottomrule
         \end{tabular}
       \end{table}

--- a/main.tex
+++ b/main.tex
@@ -34,6 +34,12 @@
 \usepackage{multirow}
 \usepackage{afterpage}
 % \usepackage[table,x11names]{xcolor}
+\usepackage{array}
+
+% A table column type for adding extra space to the left of the row. Used to
+% replace vertical rules. Requires the array package.
+\newcolumntype{C}{@{\hspace{1cm}}c}
+\newcolumntype{H}{c<{\hspace{1cm}}}
 
 \pagestyle{plain}
 


### PR DESCRIPTION
- Center number columns to make the headings match up.
- Replace ugly vertical rules with whitespace; vertical rules are
  somewhat taboo in typesetting because they disrupt the left-to-right eye
  motion.
- Remove some unnecessary horizontal rules; too many rules make tables
  hard to read.
- Change '1.0' to '1.00' in tables to make all values the same length.
- Replace \hline with the much prettier \midrule; the former doesn't use
  enough space between rows.
