### PR TITLE
Fix float placement

### DIFF
--- a/chap2.tex
+++ b/chap2.tex
@@ -29,7 +29,7 @@ magnitude.
 \subsection{Sloop Architecture} Sloop is a distributed image retrieval system.
 The system is divided into two major components:
 
-\begin{figure}[ht]
+\begin{figure}[htb]
   \centering
   \includegraphics[width=\textwidth]{sloop/system}
   \caption{Score Distribution}

--- a/chap3.tex
+++ b/chap3.tex
@@ -14,7 +14,7 @@ All the experiments in this study are conducted on a database two species of
 skinks: \emph{Grand} and \emph{Otago} of 3687 images in total created by
 biologists at New Zealand Department of Conservation. 
 
-\begin{figure}[ht]
+\begin{figure}[htb]
   \centering
   \subfloat{\includegraphics[width=4cm]{dataset/general/grand_L3}}
   \subfloat{\includegraphics[width=4cm]{dataset/general/grand_L1}}
@@ -35,7 +35,7 @@ variations. The images are closely cropped to include only the anterior end of
 the subjects; therefore, the size varies from 1056 $\times$ 564 to 2437
 $\times$ 1215 pixels
 
-\begin{table}[t]
+\begin{table}[htb]
 \captionsetup{justification=centering}
   \caption{Summary of each database}
   \label{database-table} %chktex 24
@@ -77,7 +77,7 @@ the capture, where a selfscore of an image is calculated from comparing the
 sift features of each image with itself.  $$\texttt{selfscore}(C) =
 \max_{\forall I_i \in C} \texttt{sift\_match}(I_i, I_i)$$ 
 
-\begin{figure}[h!]
+\begin{figure}[htb]
   \centering
   \subfloat[Selfscores]{\includegraphics[width=0.58\textwidth]
       {dataset/grand/selfscores}}\qquad
@@ -87,7 +87,7 @@ sift features of each image with itself.  $$\texttt{selfscore}(C) =
   \caption{Selfscore Distribution}
 \end{figure}
 
-\begin{figure}[h!]
+\begin{figure}[htb]
   \centering
   \subfloat[Selfscores]{\includegraphics[width=0.58\textwidth]
         {dataset/otago/selfscores}}\qquad
@@ -96,6 +96,7 @@ sift features of each image with itself.  $$\texttt{selfscore}(C) =
   \captionsetup{justification=centering}
   \caption{Selfscore Distribution}
 \end{figure}
+\FloatBarrier%
 
 \subsubsection{Scores}
 
@@ -107,14 +108,14 @@ $$\texttt{score}(C_1, C_2) = \max_{\forall I_i \in C_1 \forall I_j \in C_2}
         \texttt{selfscore}(C_2))}$$
 where $C$ is a capture and $I$ is an image in a capture.
 
-\begin{figure}[ht]
+\begin{figure}[htb]
   \centering
   \includegraphics[width=\textwidth]{dataset/grand/scores}
   \caption{Score Distribution}
   \label{fig:grand_scores} %chktex 24
 \end{figure}
 
-\begin{figure}[ht]
+\begin{figure}[htb]
   \centering
   \includegraphics[width=\textwidth]{dataset/otago/scores}
   \caption{Score Distribution}

--- a/chap4.tex
+++ b/chap4.tex
@@ -234,7 +234,7 @@ accretes precision and recall given the correct feedback information. Such
 inclination of precision and recall is expected largely due to the
 interpolation of the new information.
 
-\begin{figure}[h!]
+\begin{figure}[htbp]
   \centering
   \subfloat[Grand]{\includegraphics[width=0.8\textwidth]{pr/grand}}\\
   \subfloat[Otago]{\includegraphics[width=0.8\textwidth]{pr/otago}}
@@ -255,7 +255,7 @@ empirically, smaller batch size may upset some workers who would like to
 continuously work on the tasks. Therefore, we need to find the smallest batch
 size that is still large enough to engage the workers.
 
-\begin{figure}[h!]
+\begin{figure}[htbp]
   \centering
   \subfloat[Grand]{\includegraphics[width=0.8\textwidth]{sizes/graoc}}\\
   \subfloat[Otago]{\includegraphics[width=0.8\textwidth]{sizes/otaoc}}
@@ -263,7 +263,7 @@ size that is still large enough to engage the workers.
   \caption{Mean Average Precision (MAP) for different batch sizes ($Error=0$)}
 \end{figure}
 
-\begin{figure}[h!]
+\begin{figure}[htbp]
   \centering
   \subfloat[Grand]{\includegraphics[width=0.8\textwidth]{sizes/grtotal}}\\
   \subfloat[Otago]{\includegraphics[width=0.8\textwidth]{sizes/ottotal}}
@@ -289,7 +289,7 @@ it is able to recover from the downward phase. However, the historical merges
 resulted from the past faulty data are irrevocable, so the precision saturates
 eventually.
 
-\begin{figure}[ht]
+\begin{figure}[htb]
   \centering
   \subfloat[Grand]{\includegraphics[width=\textwidth]{errors/graoc}}
   \caption{Mean Average Precision for different probabilities of error}
@@ -308,7 +308,7 @@ this depends largely on the species of the animal that we are interested in. As
 you can see the performance of the each sampling policy differs slightly
 between grand and otago.
 
-\begin{figure}[h!]
+\begin{figure}[htbp]
   \centering
   \subfloat[Grand]{\includegraphics[width=0.8\textwidth]{policies/grand}}\\
   \subfloat[Otago]{\includegraphics[width=0.8\textwidth]{policies/otago}}

--- a/chap5.tex
+++ b/chap5.tex
@@ -17,7 +17,7 @@ feedback accelerates precision and recall of the recognition. This chapter
 presents the architecture of \emph{Sloop MTurk}, the crowdsourced relevance
 feedback integration of Sloop.
 
-\begin{figure}[ht]
+\begin{figure}[htb]
   \centering
   \includegraphics[width=0.8\textwidth]{sloop/turk_system}
   \caption{Sloop Architecture with Sloop MTurk integration}

--- a/chap6.tex
+++ b/chap6.tex
@@ -31,7 +31,7 @@ In the same way,
 $$\Pr{(score=s \mid nonmatch)} = \frac{\texttt{\# nonmatches\_whose\_score=s}}
     {\texttt{\# nonmatches}}$$
 
-\begin{figure}[h!]
+\begin{figure}[htbp]
   \centering
   \subfloat[][Probability of Score given matches/non-matches]
   {\includegraphics[width=0.95\textwidth]{dataset/grand/psm}}
@@ -46,7 +46,7 @@ $$\Pr{(score=s \mid nonmatch)} = \frac{\texttt{\# nonmatches\_whose\_score=s}}
   \label{fig:grand_dsm} %chktex 24
 \end{figure}
 
-From the plot above, we can deduct following conclusions:
+From Figure~\ref{fig:grand_dsm}, we can deduct following conclusions:
 \begin{itemize}
 \item Most of the cohorts has score between 0 and 0.07 overall so most matches
 and non-matches have score less than 0.06.
@@ -59,7 +59,7 @@ non-matches with the score in the same range. That is
 $$\Pr{(score \mid match)} > \Pr{(score \mid nonmatch)} \mbox{ where } score\in [0.08, 0.35)$$
 \end{itemize}
 
-\begin{figure}[h!]
+\begin{figure}[htbp]
   \centering
   \subfloat[][Probability of Score given matches/non-matches]
   {\includegraphics[width=0.95\textwidth]{dataset/otago/psm}}
@@ -77,7 +77,7 @@ $$\Pr{(score \mid match)} > \Pr{(score \mid nonmatch)} \mbox{ where } score\in [
 
 \subsection{Probability of a matching score at a given cohort size}
 
-\begin{figure}[ht]
+\begin{figure}[htbp]
   \centering
   \subfloat[][Probability of a matching score at a given cohort size]
   {\includegraphics[width=0.95\textwidth]{dataset/grand/pscohort}}
@@ -94,7 +94,7 @@ and $\max{(\texttt{sift\_match}(I_i, I_j))}$ should increase as the number of
 captures in a cohort increases. However, the distribution of $\Pr{(score \mid
 \#cohort)}$ for all numbers of cohorts seem to be similar to one another.
 
-\begin{figure}[ht]
+\begin{figure}[htbp]
   \centering
   \subfloat[][Probability of a matching score at a given cohort size]
   {\includegraphics[width=0.95\textwidth]{dataset/otago/pscohort}}
@@ -105,12 +105,13 @@ captures in a cohort increases. However, the distribution of $\Pr{(score \mid
   \label{fig:otago_psnoncohort} %chktex 24
 \end{figure}
 
+\FloatBarrier%
 \subsection{Earth Mover's Distance}
 
 We use Earth Mover's Distance (EMD)~\cite{emd00} as our metric to calculate the
 minimal cost required to transform $\Pr{(score \mid nonmatch)}$ to $\Pr{(score \mid match)}$.
 
-\begin{figure}[ht]
+\begin{figure}[htbp]
   \centering
   \includegraphics[width=0.95\textwidth]{dataset/grand/emd}
   \caption{Earth Mover's Distance between the probability distributions}
@@ -121,7 +122,7 @@ Initially, we also expected that the relationship between EMD and cohort size
 should be Gaussian. However, there seem to be no relationship between
 $\Pr{(score \mid nonmatch)}$ and $\Pr{(score \mid match)}$.
 
-\begin{figure}[ht]
+\begin{figure}[htbp]
   \centering
   \includegraphics[width=0.95\textwidth]{dataset/otago/emd}
   \caption{Earth Mover's Distance between the probability distributions}
@@ -133,7 +134,7 @@ $\Pr{(score \mid nonmatch)}$ and $\Pr{(score \mid match)}$.
 Entropy is the average amount of information we get from each distribution.
 $H(X|Y)$ = amount of randomness in the random variable X given the event Y.
 
-\begin{figure}[ht]
+\begin{figure}[htbp]
   \centering
   \subfloat[][Entropy of $\Pr{(score \mid match)}$ at different cohort sizes]
   {\includegraphics[width=0.95\textwidth]{dataset/grand/ent_psm}}
@@ -144,7 +145,7 @@ $H(X|Y)$ = amount of randomness in the random variable X given the event Y.
   \label{fig:grand_ent_psnm} %chktex 24
 \end{figure}
 
-\begin{figure}[ht]
+\begin{figure}[htbp]
   \centering
   \subfloat[][Entropy of $\Pr{(score \mid match)}$ at different cohort sizes]
   {\includegraphics[width=0.95\textwidth]{dataset/otago/ent_psm}}
@@ -156,6 +157,7 @@ $H(X|Y)$ = amount of randomness in the random variable X given the event Y.
   \label{fig:emd_grand} %chktex 24
 \end{figure}
 
+\FloatBarrier%
 \subsection{Probability of a Matches/Non-matches}
 
 $$\Pr{(match \mid score)} = \frac{\Pr{(score \mid match)}\Pr{(match)}}
@@ -164,14 +166,14 @@ $$\Pr{(match \mid score)} = \frac{\Pr{(score \mid match)}\Pr{(match)}}
 $$\Pr{(nonmatch \mid score)} = \frac{\Pr{(score \mid nonmatch)}\Pr{(nonmatch)}}
     {\Pr{(score)}}$$
 
-\begin{figure}[ht]
+\begin{figure}[htbp]
   \centering
   \includegraphics[width=0.95\textwidth]{dataset/grand/pms}
   \caption{Probability of matches/non-matches given score}
   \label{fig:grand_pms} %chktex 24
 \end{figure}
 
-\begin{figure}[ht]
+\begin{figure}[htbp]
   \centering
   \includegraphics[width=0.95\textwidth]{dataset/otago/pms}
   \caption{Probability of matches/non-matches given score}
@@ -204,7 +206,7 @@ Normal sampling policy.
 
 \section{Results}
 
-\begin{figure}[h!]
+\begin{figure}[htb]
   \centering
   \includegraphics[width=0.8\textwidth]{otago}
   \caption{Mean Average Precision for the new sampling policies}

--- a/chap7.tex
+++ b/chap7.tex
@@ -23,7 +23,7 @@ in image A the same individual as the animal in image B.
 The proposed architecture comprises two major modules shown in
 Figure~\ref{fig:cnn_overview}.
 
-\begin{figure}[ht]
+\begin{figure}[htb]
   \centering
   \includegraphics[width=\textwidth]{system/overview}
   \caption{System Overview}
@@ -60,7 +60,7 @@ We map all the available images as well as the input image to points in a low
 dimensional space (4096-D compare to $227 \times 227$-D) using the
 aforementioned CNN architecture. 
 
-\begin{figure}[h!]
+\begin{figure}[htbp]
   \centering
   \subfloat[][The first layer filters, \texttt{conv1}]
     {\includegraphics[width=8cm]{preprocess/paramconv1}}\\

--- a/main.tex
+++ b/main.tex
@@ -33,6 +33,7 @@
 \usepackage{pdflscape}
 \usepackage{multirow}
 \usepackage{afterpage}
+\usepackage{placeins}
 % \usepackage[table,x11names]{xcolor}
 
 \pagestyle{plain}


### PR DESCRIPTION
The 'h!' float placement specifiers were not doing what was intended.
The '!' does more harm than good.  To remedy this:
- Use at least 'htb' for most floats.
- For large floats, or when there are two together, add 'p', which
  allows placing them on a dedicated float page.
- Add the placeins package, which provides \FloatBarrier.
