### PR TITLE
Fix equation formatting in chapter 4

### DIFF
--- a/chap4.tex
+++ b/chap4.tex
@@ -171,42 +171,47 @@ number of pairs sampled to reach convergence for each batch size.
 \subsection{Errors} % (fold)
 \label{sub:errors}
 
-Despite all the preventive measures, i.e. task distribution and the gold standard
-questions, there is probability of obtaining an incorrect answer, assuming
+Despite all the preventive measures, i.e.\ task distribution and the gold standard
+questions, there is a probability of obtaining an incorrect answer, assuming
 that all the events are independent.
 
-Suppose each HIT is distributed to $n$ workers -- or, in other words, each HIT
+Suppose each HIT is distributed to $n$ workers, or in other words, each HIT
 contains $n$ assignments and there are $m$ questions for each assignments.
 For each assignment, the chance that an assignment is accepted with
 an incorrect answer to the unknown pair is $\frac{1}{2^m}$, and the chance
 that an assignment is rejected is $\epsilon_m = (1-\frac{1}{2^{m-1}})$
 
-In the case that only one assignment, out of $n$ assignments, is accepted with
+The probability that only one assignment out of $n$ assignments is accepted with
 an incorrect answer to the unknown pair is
-$$\epsilon_m^{n-1} \cdot \frac{1}{2^m}$$.
-In the case that two assignment are accepted, but the resulting answer to the
-unknown pair is incorrect
-$$\epsilon_m^{n-2} \cdot \binom{2}{2}\frac{1}{2^{2\cdot m}} \mbox{if both are incorrect}$$.
-$$\epsilon_m^{n-2} \cdot \binom{2}{1}\frac{1}{2^{2\cdot m}} \mbox{if both answers do not match and the actual answer is the same}$$.
+$$\epsilon_m^{n-1} \cdot \frac{1}{2^m}$$
+The probability that two assignments are accepted, but the resulting answer to the
+unknown pair is incorrect is
+$$\epsilon_m^{n-2} \cdot \binom{2}{2}\frac{1}{2^{2\cdot m}}$$
+if both are incorrect, and
+$$\epsilon_m^{n-2} \cdot \binom{2}{1}\frac{1}{2^{2\cdot m}}$$
+if both answers are `do not match' and the actual answer is the same.
 The error rate in this case is thus
-$$3 \cdot \epsilon_m^{n-2} \cdot \frac{1}{2^{2\cdot m}} \mbox{if both answers do not match and the actual answer is the same}$$.
-In the case that three assignment are accepted, but the resulting answer to the
-unknown pair is incorrect
-$$\epsilon_m^{n-3} \cdot \binom{3}{3}\frac{1}{2^{3\cdot m}} \mbox{if all are incorrect}$$.
-$$\epsilon_m^{n-3} \cdot \binom{3}{2}\frac{1}{2^{3\cdot m}} \mbox{if two are incorrect}$$.
+$$3 \cdot \epsilon_m^{n-2} \cdot \frac{1}{2^{2\cdot m}}$$
+if both answers are `do not match' and the actual answer is the same.
+The probability that three assignments are accepted, but the resulting answer to the
+unknown pair is incorrect is
+$$\epsilon_m^{n-3} \cdot \binom{3}{3}\frac{1}{2^{3\cdot m}}$$
+if all are incorrect, and
+$$\epsilon_m^{n-3} \cdot \binom{3}{2}\frac{1}{2^{3\cdot m}}$$
+if two are incorrect.
 The error rate in this case is thus
-$$4 \epsilon_m^{n-3} \cdot \frac{1}{2^{3\cdot m}} \mbox{if two are incorrect}$$.
-...
+$$4 \epsilon_m^{n-3} \cdot \frac{1}{2^{3\cdot m}}$$
+if two are incorrect.
 Let $i$ be the number of assignments accepted and 
 $\epsilon_{nm} = \frac{1}{2^m\epsilon_m}$.
-The error rate can be generalized as following:
+The error rate can be generalized as follows:
 \begin{description}
-  \item[$i$ is odd]
-  $$(\binom{i}{i} + \binom{i}{i-1} + ... + \binom{i}{\frac{i+1}{2}})\epsilon_{nm}^i \epsilon_m^n$$
-  \item[$n$ is even]
-  $$(\binom{i}{i} + \binom{i}{i-1} + ... + \binom{i}{\frac{i}{2}})\epsilon_{nm}^i \epsilon_m^n$$
+  \item[$i$ is odd:]
+  $$(\binom{i}{i} + \binom{i}{i-1} + \cdots + \binom{i}{\frac{i+1}{2}})\epsilon_{nm}^i \epsilon_m^n$$
+  \item[$n$ is even:]
+  $$(\binom{i}{i} + \binom{i}{i-1} + \cdots + \binom{i}{\frac{i}{2}})\epsilon_{nm}^i \epsilon_m^n$$
 \end{description}
-By binomial theroem, the total error rate is bounded by
+By the binomial theorem, the total error rate is bounded by
 
 
 


### PR DESCRIPTION
Equations with $$ should always be alone on a line so they line up with
the ones above them.  Move the text out of the mboxes to make this work.

This also fixes some errors with punctuation rendering in the wrong
places.
